### PR TITLE
Adjust method signatures to match parent

### DIFF
--- a/action.php
+++ b/action.php
@@ -33,7 +33,7 @@ class action_plugin_dwinsect extends DokuWiki_Action_Plugin {
    * Register the eventhandlers
    * @see DokuWiki_Action_Plugin::register()
    */
-  function register(&$controller) {
+  function register(Doku_Event_Handler $controller) {
   	$controller->register_hook('TOOLBAR_DEFINE', 'AFTER', $this, 'insert_button', array()); 
   }
   

--- a/syntax.php
+++ b/syntax.php
@@ -116,7 +116,7 @@ class syntax_plugin_dwinsect extends DokuWiki_Syntax_Plugin {
    /**
    * Handle the match
    */
-  function handle($match, $state, $pos, &$handler){
+  function handle($match, $state, $pos, Doku_Handler $handler){
   	
 	  switch ($state) {
 			case DOKU_LEXER_ENTER:
@@ -206,7 +206,7 @@ class syntax_plugin_dwinsect extends DokuWiki_Syntax_Plugin {
   /**
    * Create output
    */
-	function render($mode, &$renderer, $data) {
+	function render($mode, Doku_Renderer $renderer, $data) {
 
 		if($mode == 'xhtml'){
 			list($state, $result) = $data;


### PR DESCRIPTION
Starting with PHP 7, classes that overide methods from their parent have to match their parent's method signature regarding type hints. Otherwise PHP will throw an error.

Your plugin seems not to match DokuWiki's method signatures causing it to fail under PHP7. This patch tries to fix that.

Please note that this patch and the resulting pull request were created using an automated tool. Something might have gone, wrong so please carefully check before merging.

If you think the code submitted is wrong, please feel free to close this PR and excuse the mess.
